### PR TITLE
bump android studio and dependencies, compile with java 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: android
 android:
   components:
-    - build-tools-28.0.3
-    - android-28
     - tools
     - platform-tools
+    - tools
+    - build-tools-28.0.3
+    - android-28
+
   licenses:
     - 'android-sdk-license-.+'
-
+    - 'android-preview-sdk-license-.+'
+    - '-.+'
 
 script:
-    - ./gradlew check
-    - ./gradlew desktop:build
-    - ./gradlew android:build
+  - ./gradlew check
+  - ./gradlew desktop:build
+  - ./gradlew android:build
 
 cache:
   directories:

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,10 @@ This is a FOSS drum app for Android.
 
 .. raw:: html
 
-   <a href="https://f-droid.org/app/se.tube42.drum.android"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="100"></a>
+<a href="https://f-droid.org/packages/se.tube42.drum.android">
+	<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
+	alt="Get it on F-Droid" height="80">
+</a>
 
 
 .. image:: extra/screenshot/demo.gif

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 android {
-    buildToolsVersion "28.0.2"
+    buildToolsVersion "28.0.3"
     compileSdkVersion 28
     sourceSets {
         main {
@@ -27,6 +27,11 @@ android {
         versionName "0.2.8"
 
     }
+	compileOptions {
+        encoding = 'UTF-8'
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 
@@ -34,11 +39,11 @@ android {
 // the natives configuration, and extracts them to the proper libs/ folders
 // so they get packed with the APK.
 task copyAndroidNatives() {
-    file("libs/armeabi/").mkdirs();
-    file("libs/armeabi-v7a/").mkdirs();
-    file("libs/arm64-v8a/").mkdirs();
-    file("libs/x86_64/").mkdirs();
-    file("libs/x86/").mkdirs();
+    file("libs/armeabi/").mkdirs()
+    file("libs/armeabi-v7a/").mkdirs()
+    file("libs/arm64-v8a/").mkdirs()
+    file("libs/x86_64/").mkdirs()
+    file("libs/x86/").mkdirs()
 
     configurations.natives.files.each { jar ->
         def outputDir = null

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,12 @@ buildscript {
         mavenLocal()
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+		maven { url "https://oss.sonatype.org/content/repositories/releases/" }
         jcenter()
+		google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -16,11 +18,11 @@ allprojects {
 
     ext {
         appName = "Drum On"
-        gdxVersion = '1.9.7'
-        roboVMVersion = '2.3.1'
+        gdxVersion = '1.9.9'
+        roboVMVersion = '2.3.5'
         box2DLightsVersion = '1.4'
-        ashleyVersion = '1.7.0'
-        aiVersion = '1.8.0'
+        ashleyVersion = '1.7.3'
+        aiVersion = '1.8.1'
     }
 
     repositories {
@@ -29,6 +31,7 @@ allprojects {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
 		jcenter()
+		google()
     }
 }
 
@@ -45,7 +48,7 @@ project(":desktop") {
 }
 
 project(":android") {
-    apply plugin: "android"
+    apply plugin: "com.android.application"
 
     configurations { natives }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.6
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.6
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "se.tube42.drum.desktop.DesktopMain"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Dec 15 17:29:58 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
I did this through a text editor; no Android Studio.
- Android Studio 1.5.0 -> 3.2.1
- gdx 1.9.7 -> 1.9.9
- roboVM 2.3.1 -> 2.3.5
- ashley 1.7.0 -> 1.7.3
- ai 1.8.0 -> 1.8.1
- Gradle 2.10 -> 4.10.3
- make everything compile with java 1.8
- change android plugin from android to com.android.application
- buildToolsVersion 28.0.2 -> 28.0.3 in android/build.gradle
- remove redundant semicolons in android/build.gradle